### PR TITLE
RoboVM support etc.

### DIFF
--- a/server/src/main/java/com/fastcgi/FCGIInputStream.java
+++ b/server/src/main/java/com/fastcgi/FCGIInputStream.java
@@ -19,7 +19,6 @@
 
 package com.fastcgi;
 
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
@@ -58,7 +57,7 @@ public class FCGIInputStream extends InputStream {
      * @param bufLen     length of buffer
      * @param streamType
      */
-    public FCGIInputStream(FileInputStream inStream, int bufLen, int streamType, FCGIRequest inReq) {
+    public FCGIInputStream(InputStream inStream, int bufLen, int streamType, FCGIRequest inReq) {
 
         in = inStream;
         buffLen = Math.min(bufLen, FCGIConstants.MAX_BUFFER_LENGTH);
@@ -189,7 +188,7 @@ public class FCGIInputStream extends InputStream {
                     setException(e);
                     return;
                 }
-                if (count == 0) {
+                if (count <= 0) {
                     setFCGIError(FCGIConstants.ERROR_PROTOCOL_ERROR);
                     return;
                 }

--- a/server/src/main/java/com/fastcgi/FCGIInterface.java
+++ b/server/src/main/java/com/fastcgi/FCGIInterface.java
@@ -20,8 +20,6 @@ package com.fastcgi;
 
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.net.ServerSocket;
@@ -88,7 +86,7 @@ public class FCGIInterface {
          * If not first call, and  we are cgi, we should be gone.
          */
         if (!acceptCalled) {
-            isFCGI = System.getProperties().containsKey("FCGI_PORT");
+            isFCGI = System.getenv("FCGI_PORT") != null;
             acceptCalled = true;
             if (isFCGI) {
                 /*
@@ -96,7 +94,7 @@ public class FCGIInterface {
                  * and get a server socket
                  */
                 startupProps = new Properties(System.getProperties());
-                String str = System.getProperty("FCGI_PORT");
+                String str = System.getenv("FCGI_PORT");
                 if (str.length() <= 0) {
                     return false;
                 }
@@ -210,7 +208,7 @@ public class FCGIInterface {
              * try making a new connection before giving up
              */
             request.setBeginProcessed(false);
-            request.setInputStream(new FCGIInputStream((FileInputStream) request.getSocket().getInputStream(),
+            request.setInputStream(new FCGIInputStream(request.getSocket().getInputStream(),
                     8192, 0, request));
             request.getInputStream().fill();
             if (request.isBeginProcessed()) {
@@ -236,10 +234,10 @@ public class FCGIInterface {
             return false;
         }
         request.getInputStream().setReaderType(FCGIConstants.TYPE_STDIN);
-        request.setOutputStream(new FCGIOutputStream((FileOutputStream) request.getSocket().
+        request.setOutputStream(new FCGIOutputStream(request.getSocket().
                 getOutputStream(), 8192,
                 FCGIConstants.TYPE_STDOUT, request));
-        request.setErrorStream(new FCGIOutputStream((FileOutputStream) request.getSocket().
+        request.setErrorStream(new FCGIOutputStream(request.getSocket().
                 getOutputStream(), 512,
                 FCGIConstants.TYPE_STDERR, request));
         request.setNumWriters(2);

--- a/server/src/main/java/com/fastcgi/FCGIOutputStream.java
+++ b/server/src/main/java/com/fastcgi/FCGIOutputStream.java
@@ -19,7 +19,6 @@
 package com.fastcgi;
 
 import java.io.EOFException;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 
@@ -48,7 +47,7 @@ public class FCGIOutputStream extends OutputStream {
     private boolean rawWrite;
     private FCGIRequest request;
 
-    private FileOutputStream out;
+    private OutputStream out;
 
     /**
      * Creates a new output stream to manage fcgi prototcol stuff
@@ -57,7 +56,7 @@ public class FCGIOutputStream extends OutputStream {
      * @param bufLen     length of buffer
      * @param streamType
      */
-    public FCGIOutputStream(FileOutputStream outStream,
+    public FCGIOutputStream(OutputStream outStream,
                             int bufLen, int streamType,
                             FCGIRequest inreq) {
         out = outStream;


### PR DESCRIPTION
Hi,

The unnecessary casting to File{Input,Output}Stream provokes a ClassCastException on RoboVM, where the SocketStreams do not subclass the FileStream classes. I consider this change uncontroversial.

On RoboVM, I don't think there are any properties, so I changed to using environment variables instead. If you do not like this, I can remove this change. I don't see the advantage of Java properties though.

The last change is something I did years ago. read can return -1 on EOF, and I guess EOF and just no bytes should be handled equivalently here. So the change makes sense to me, but I didn't test without this change. I can try that if you don't wanna merge it like this, but I am pretty sure it was necessary for me in some particular setup a few years ago.