### PR TITLE
Fix for #21, change HTTP_PROXY to CGI_HTTP_PROXY

### DIFF
--- a/client/core/src/main/java/org/jfastcgi/client/FastCGIHandler.java
+++ b/client/core/src/main/java/org/jfastcgi/client/FastCGIHandler.java
@@ -19,6 +19,14 @@
  */
 package org.jfastcgi.client;
 
+import org.apache.commons.exec.*;
+import org.jfastcgi.api.ConnectionFactory;
+import org.jfastcgi.api.RequestAdapter;
+import org.jfastcgi.api.ResponseAdapter;
+import org.jfastcgi.utils.logging.StreamLogger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -27,65 +35,29 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.regex.Pattern;
 
-import org.apache.commons.exec.CommandLine;
-import org.apache.commons.exec.DefaultExecuteResultHandler;
-import org.apache.commons.exec.DefaultExecutor;
-import org.apache.commons.exec.ExecuteException;
-import org.apache.commons.exec.ExecuteStreamHandler;
-import org.apache.commons.exec.ExecuteWatchdog;
-import org.apache.commons.exec.Executor;
-import org.jfastcgi.api.ConnectionFactory;
-import org.jfastcgi.api.RequestAdapter;
-import org.jfastcgi.api.ResponseAdapter;
-import org.jfastcgi.utils.logging.StreamLogger;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /**
  * handling of the fastCGI protocol.
  */
 public class FastCGIHandler {
 
-    private static interface HeaderFilter {
-        public boolean isFiltered(String header);
-    }
-
     private static final Logger LOGGER = LoggerFactory.getLogger(FastCGIHandler.class);
-
     private static final int HTTP_ERROR_BAD_GATEWAY = 502;
-
     private static final int FCGI_BEGIN_REQUEST = 1;
-
     private static final int FCGI_END_REQUEST = 3;
-
     private static final int FCGI_PARAMS = 4;
-
     private static final int FCGI_STDIN = 5;
-
     private static final int FCGI_STDOUT = 6;
-
     private static final int FCGI_STDERR = 7;
-
     private static final int FCGI_RESPONDER = 1;
-
     private static final int FCGI_VERSION = 1;
-
     private static final int FCGI_KEEP_CONN = 1;
-
     private static final int FCGI_REQUEST_COMPLETE = 0;
-
     private static final long READ_TIMEOUT = 120000;
-
     private ConnectionFactory connectionFactory;
-
     private Executor processExecutor;
-
     private Thread processLogThread;
-
     private boolean keepAlive = false;
-
     private short requestId = 1;
-    
     /**
      * by default, no header is filtered.
      */
@@ -104,7 +76,7 @@ public class FastCGIHandler {
     private synchronized short newRequestId() {
         return requestId++;
     }
-    
+
     /**
      * Some http headers have sometimes to be filtered for security reasons, so
      * this methods allows to tell which http headers we do not want to pass to
@@ -278,7 +250,7 @@ public class FastCGIHandler {
     private void setEnvironment(final OutputStream ws, final RequestAdapter req) throws IOException {
         if (req.getQueryString() != null) {
             addHeader(ws, "REQUEST_URI", req.getRequestURI()+"?"+req.getQueryString());
-        } 
+        }
         else {
             addHeader(ws, "REQUEST_URI", req.getRequestURI());
         }
@@ -343,8 +315,10 @@ public class FastCGIHandler {
                 }
                 else if (key.equalsIgnoreCase("content-type")) {
                     addHeader(ws, "CONTENT_TYPE", value);
-                }
-                else {
+                } else if(key.equalsIgnoreCase("PROXY")) {
+                    //Avoid to pass HTTP_PROXY to the script (https://github.com/jFastCGI/jfastcgi/issues/21)
+                    addHeader(ws, "CGI_HTTP_PROXY", value);
+                } else {
                     addHeader(ws, convertHeader(key), value);
                 }
             }
@@ -491,7 +465,7 @@ public class FastCGIHandler {
         ws.write(length);
         ws.write(pad);
         ws.write(0);
-        
+
         getLog().debug("fcgi request id : " + id);
         return id;
     }
@@ -501,6 +475,30 @@ public class FastCGIHandler {
             processExecutor.getWatchdog().destroyProcess();
             processExecutor = null;
         }
+    }
+
+    public Thread getProcessLogThread() {
+        return processLogThread;
+    }
+
+    public boolean isKeepAlive() {
+        return keepAlive;
+    }
+
+    public void setKeepAlive(final boolean keepAlive) {
+        this.keepAlive = keepAlive;
+    }
+
+    public ConnectionFactory getConnectionFactory() {
+        return connectionFactory;
+    }
+
+    public void setConnectionFactory(final ConnectionFactory connectionFactory) {
+        this.connectionFactory = connectionFactory;
+    }
+
+    private static interface HeaderFilter {
+        public boolean isFiltered(String header);
     }
 
     static class FastCGIInputStream extends InputStream {
@@ -556,7 +554,7 @@ public class FastCGIHandler {
             int version;
 
             while ((version = _is.read()) >= 0) {
-                
+
                 final int type = _is.read();
 
                 @SuppressWarnings("unused")
@@ -566,7 +564,7 @@ public class FastCGIHandler {
                 _is.read();
 
                 switch (type) {
-                case FCGI_END_REQUEST: 
+                case FCGI_END_REQUEST:
                     final int appStatus = (_is.read() << 24) + (_is.read() << 16) + (_is.read() << 8) + _is.read();
                     final int pStatus = _is.read();
 
@@ -586,7 +584,7 @@ public class FastCGIHandler {
                     _is.skip(3);
                     _is = null;
                     return false;
-                
+
 
                 case FCGI_STDOUT:
                     if (getLog().isDebugEnabled()) {
@@ -633,26 +631,6 @@ public class FastCGIHandler {
 
             return false;
         }
-    }
-
-    public Thread getProcessLogThread() {
-        return processLogThread;
-    }
-
-    public boolean isKeepAlive() {
-        return keepAlive;
-    }
-
-    public void setKeepAlive(final boolean keepAlive) {
-        this.keepAlive = keepAlive;
-    }
-
-    public ConnectionFactory getConnectionFactory() {
-        return connectionFactory;
-    }
-
-    public void setConnectionFactory(final ConnectionFactory connectionFactory) {
-        this.connectionFactory = connectionFactory;
     }
 
 }

--- a/client/core/src/main/java/org/jfastcgi/client/FastCGIHandler.java
+++ b/client/core/src/main/java/org/jfastcgi/client/FastCGIHandler.java
@@ -19,7 +19,14 @@
  */
 package org.jfastcgi.client;
 
-import org.apache.commons.exec.*;
+import org.apache.commons.exec.CommandLine;
+import org.apache.commons.exec.DefaultExecuteResultHandler;
+import org.apache.commons.exec.DefaultExecutor;
+import org.apache.commons.exec.ExecuteStreamHandler;
+import org.apache.commons.exec.ExecuteException;
+import org.apache.commons.exec.ExecuteWatchdog;
+import org.apache.commons.exec.Executor;
+
 import org.jfastcgi.api.ConnectionFactory;
 import org.jfastcgi.api.RequestAdapter;
 import org.jfastcgi.api.ResponseAdapter;
@@ -315,10 +322,12 @@ public class FastCGIHandler {
                 }
                 else if (key.equalsIgnoreCase("content-type")) {
                     addHeader(ws, "CONTENT_TYPE", value);
-                } else if(key.equalsIgnoreCase("PROXY")) {
+                }
+                else if(key.equalsIgnoreCase("PROXY")) {
                     //Avoid to pass HTTP_PROXY to the script (https://github.com/jFastCGI/jfastcgi/issues/21)
                     addHeader(ws, "CGI_HTTP_PROXY", value);
-                } else {
+                }
+                else {
                     addHeader(ws, convertHeader(key), value);
                 }
             }

--- a/client/core/src/test/java/org/jfastcgi/client/FastCGIHandlerTest.java
+++ b/client/core/src/test/java/org/jfastcgi/client/FastCGIHandlerTest.java
@@ -1,0 +1,88 @@
+package org.jfastcgi.client;
+
+import org.jfastcgi.api.ConnectionFactory;
+import org.jfastcgi.api.RequestAdapter;
+import org.jfastcgi.api.ResponseAdapter;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class FastCGIHandlerTest {
+
+    private ByteArrayOutputStream outputStream;
+
+    private ByteArrayInputStream inputStream;
+
+    @Before
+    public void setup() {
+        outputStream = new ByteArrayOutputStream();
+        inputStream = new ByteArrayInputStream(new byte[]{});
+    }
+
+
+    protected ISocket makeISocket() throws IOException {
+        ISocket iSocket = Mockito.mock(ISocket.class);
+        Mockito.when(iSocket.getOutputStream()).thenReturn(outputStream);
+        Mockito.when(iSocket.getInputStream()).thenReturn(inputStream);
+        return iSocket;
+    }
+
+    protected ConnectionFactory makeConnectionFactory() throws IOException {
+        final ISocket iSocket = makeISocket();
+        ConnectionFactory connectionFactory = Mockito.mock(ConnectionFactory.class);
+        Mockito.when(connectionFactory.getConnection()).thenReturn(iSocket);
+        return connectionFactory;
+    }
+
+    protected RequestAdapter makeRequest(final Map<String, String> headers) {
+        RequestAdapter request = Mockito.mock(RequestAdapter.class);
+        Mockito.when(request.getServletPath()).thenReturn("/fcgi");
+        Mockito.when(request.getHeaderNames()).thenReturn(Collections.enumeration(headers.keySet()));
+
+        Mockito.when(request.getHeader(Mockito.anyString())).then(new Answer<String>() {
+            public String answer(InvocationOnMock invocationOnMock) throws Throwable {
+                Object arg = invocationOnMock.getArguments()[0];
+                String key = arg == null ? null : arg.toString();
+                return headers.get(key);
+            }
+        });
+
+        Mockito.when(request.getInputStream()).thenReturn(new ByteArrayInputStream(new byte[]{}));
+        return request;
+    }
+
+    /**
+     * (Fixing https://github.com/jFastCGI/jfastcgi/issues/21)
+     * <p>
+     * Check that the HTTP_PROXY environment variable is not transmitted when the 'Proxy' header
+     * is set in the request.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testProxyHeader() throws Exception {
+
+        FastCGIHandler fastCGIHandler = new FastCGIHandler();
+        fastCGIHandler.setConnectionFactory(makeConnectionFactory());
+
+        ResponseAdapter response = Mockito.mock(ResponseAdapter.class);
+
+        Map<String, String> headers = new HashMap<String, String>();
+        headers.put("Proxy", "proxyValue");
+
+        fastCGIHandler.service(makeRequest(headers), response);
+
+        String s = new String(outputStream.toByteArray());
+        Assert.assertTrue(s.contains("CGI_HTTP_PROXY")); //same fix as ruby, we change the name of the variable
+    }
+}


### PR DESCRIPTION
Avoid the name clash that causes the security issue described at https://httpoxy.org/.
This is the name solution as what ruby and libww-perl do.