### PR TITLE
Get rid of Maven warnings about inconsistency with parent.relativePath

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -5,7 +5,8 @@
        <groupId>org.sonatype.oss</groupId>
        <artifactId>oss-parent</artifactId>
        <version>7</version>
-     </parent>
+       <relativePath/>
+    </parent>
 
     <groupId>org.jfastcgi.parent</groupId>
     <artifactId>jfastcgi-parent</artifactId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -22,6 +22,8 @@
     </modules>
 
     <properties>
+        <maven.compiler.source>1.6</maven.compiler.source>
+        <maven.compiler.target>1.6</maven.compiler.target>
         <commons-pool2.version>2.2</commons-pool2.version>
         <commons-exec.version>1.2</commons-exec.version>
         <portlet-api.version>2.0</portlet-api.version>


### PR DESCRIPTION
Get rid of warnings like

[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.jfastcgi.parent:jfastcgi-parent:pom:2.4-SNAPSHOT
[WARNING] 'parent.relativePath' of POM org.jfastcgi.parent:jfastcgi-parent:2.4-SNAPSHOT (/home/jan/dev/git/jfastcgi/parent/pom.xml) points at org.jfastcgi.parent:jfastcgi-build instead of org.sonatype.oss:oss-parent, please verify your project structure @ line 4, column 13
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING]

Solution found here:

https://stackoverflow.com/questions/37062491/maven-complaining-about-parent-relative-path