### PR TITLE
Three changes: Some Maven things, CONTENT_TYPE and some more allowed HTTP headers.

### DIFF
--- a/client/core/src/main/java/org/jfastcgi/api/RequestAdapter.java
+++ b/client/core/src/main/java/org/jfastcgi/api/RequestAdapter.java
@@ -51,6 +51,8 @@ public interface RequestAdapter {
     public String getProtocol();
 
     public String getQueryString();
+    
+    public String getContentType();
 
     public String getServletPath();
     

--- a/client/core/src/main/java/org/jfastcgi/client/FastCGIHandler.java
+++ b/client/core/src/main/java/org/jfastcgi/client/FastCGIHandler.java
@@ -261,6 +261,9 @@ public class FastCGIHandler {
         else {
             addHeader(ws, "REQUEST_URI", req.getRequestURI());
         }
+        if (req.getContentType() != null) {
+            addHeader(ws, "CONTENT_TYPE", req.getContentType());
+        }
         addHeader(ws, "REQUEST_METHOD", req.getMethod());
         addHeader(ws, "SERVER_SOFTWARE", FastCGIHandler.class.getName());
         addHeader(ws, "SERVER_NAME", req.getServerName());

--- a/client/core/src/main/java/org/jfastcgi/client/FastCGIHandler.java
+++ b/client/core/src/main/java/org/jfastcgi/client/FastCGIHandler.java
@@ -75,8 +75,9 @@ public class FastCGIHandler {
 
         private Pattern p = Pattern.compile(
                 "ACCEPT[-0-9A-Z]{0,100}|AUTHORIZATION|CACHE-CONTROL|COOKIE|DEPTH"
-                + "|HOST|IF-[-0-9A-Z]{2,100}|OCS-APIREQUEST|REFERER|REQUESTTOKEN"
-                + "|USER-AGENT|X-FORWARDED-FOR|X-UPDATER-AUTH");
+                + "|DESTINATION|HOST|IF-[-0-9A-Z]{2,100}|OCS-APIREQUEST|OVERWRITE"
+                + "|REFERER|REQUESTTOKEN|USER-AGENT|X-FORWARDED-FOR"
+                + "|X-REQUESTED-WITH|X-UPDATER-AUTH");
 
         public boolean isAllowed(final String header) {
             return p.matcher(header.toUpperCase()).matches();
@@ -96,9 +97,11 @@ public class FastCGIHandler {
      * this methods allows to tell which http headers we do want to pass to
      * the fastcgi app. Default is: <code>
      * java.util.Pattern.compile(
-     *    "ACCEPT[-0-9A-Z]{0,100}|AUTHORIZATION|CACHE-CONTROL|COOKIE|DEPTH|HOST|IF-[-0-9A-Z]{2,100}|OCS-APIREQUEST|REFERER|REQUESTTOKEN|USER-AGENT|X-FORWARDED-FOR|X-UPDATER-AUTH");
+     *      "ACCEPT[-0-9A-Z]{0,100}|AUTHORIZATION|CACHE-CONTROL|COOKIE|DEPTH"
+     *      + "|DESTINATION|HOST|IF-[-0-9A-Z]{2,100}|OCS-APIREQUEST|OVERWRITE"
+     *      + "|REFERER|REQUESTTOKEN|USER-AGENT|X-FORWARDED-FOR"
+     *      + "|X-REQUESTED-WITH|X-UPDATER-AUTH");
      * </code>
-     * <p/>
      *
      * @param allowedHeaders
      *            a regular expression for allowed http headers that will be

--- a/client/portlet/src/main/java/org/jfastcgi/portlet/impl/PortletRequestAdapter.java
+++ b/client/portlet/src/main/java/org/jfastcgi/portlet/impl/PortletRequestAdapter.java
@@ -59,6 +59,10 @@ public class PortletRequestAdapter implements RequestAdapter {
     public String getQueryString() {
         return "";
     }
+    
+    public String getContentType() {
+        return null;
+    }
 
     public String getRemoteAddr() {
         return "";

--- a/client/servlet/src/main/java/org/jfastcgi/servlet/impl/ServletRequestAdapter.java
+++ b/client/servlet/src/main/java/org/jfastcgi/servlet/impl/ServletRequestAdapter.java
@@ -81,6 +81,10 @@ public class ServletRequestAdapter implements RequestAdapter {
     public String getQueryString() {
         return httpServletRequest.getQueryString();
     }
+    
+    public String getContentType() {
+        return httpServletRequest.getContentType();
+    }
 
     public String getRemoteAddr() {
         return httpServletRequest.getRemoteAddr();

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -5,6 +5,7 @@
        <groupId>org.sonatype.oss</groupId>
        <artifactId>oss-parent</artifactId>
        <version>7</version>
+       <relativePath/>
      </parent>
 
     <groupId>org.jfastcgi.parent</groupId>
@@ -21,6 +22,8 @@
     </modules>
 
     <properties>
+    	<maven.compiler.source>1.6</maven.compiler.source>
+    	<maven.compiler.target>1.6</maven.compiler.target>
         <commons-pool2.version>2.2</commons-pool2.version>
         <commons-exec.version>1.2</commons-exec.version>
         <portlet-api.version>2.0</portlet-api.version>
@@ -238,23 +241,16 @@
                     <execution>
                         <id>verify-style</id>
                         <phase>process-classes</phase>
+                        <configuration>
+                            <configLocation>build-tools/src/main/resources/checkstyle/checkstyle-default.xml</configLocation>
+                            <consoleOutput>true</consoleOutput>
+                            <includeTestSourceDirectory>false</includeTestSourceDirectory>
+                        </configuration>
                         <goals>
                             <goal>check</goal>
                         </goals>
                     </execution>
                 </executions>
-                <configuration>
-                    <configLocation>checkstyle/checkstyle-default.xml</configLocation>
-                    <consoleOutput>true</consoleOutput>
-                    <includeTestSourceDirectory>false</includeTestSourceDirectory>
-                </configuration>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.jfastcgi.parent</groupId>
-                        <artifactId>build-tools</artifactId>
-                        <version>${project.version}</version>
-                    </dependency>
-                </dependencies>
             </plugin>
             <plugin>
                 <groupId>org.zeroturnaround</groupId>


### PR DESCRIPTION
**1) Maven:**

**a)**
Get rid of warnings like

[WARNING]
[WARNING] Some problems were encountered while building the effective model for org.jfastcgi.parent:jfastcgi-parent:pom:2.4-SNAPSHOT
[WARNING] 'parent.relativePath' of POM org.jfastcgi.parent:jfastcgi-parent:2.4-SNAPSHOT (/home/jan/dev/git/jfastcgi/parent/pom.xml) points at org.jfastcgi.parent:jfastcgi-build instead of org.sonatype.oss:oss-parent, please verify your project structure @ line 4, column 13
[WARNING]
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING]
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING]

Solution found here:

https://stackoverflow.com/questions/37062491/maven-complaining-about-parent-relative-path

**b)**
Building everything with jfastcgi-build worked, but when I chose single projects like for example client-core, I got errors like:
[INFO] ------------------------------------------------------------------------
[INFO] Building jFastCGI Client: CORE 2.4-SNAPSHOT
[INFO] ------------------------------------------------------------------------
[INFO] 
[INFO] --- maven-enforcer-plugin:1.0:enforce (enforce-maven) @ client-core ---
[INFO] 
[INFO] --- maven-resources-plugin:2.6:resources (default-resources) @ client-core ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] skip non existing resourceDirectory /home/xxx/dev/git/jfastcgi/client/core/src/main/resources
[INFO] 
[INFO] --- jrebel-maven-plugin:1.1.3:generate (generate-rebel-xml) @ client-core ---
[INFO] 
[INFO] --- maven-compiler-plugin:3.1:compile (default-compile) @ client-core ---
[INFO] Changes detected - recompiling the module!
[INFO] Compiling 17 source files to /home/xxx/dev/git/jfastcgi/client/core/target/classes
[INFO] -------------------------------------------------------------
[ERROR] COMPILATION ERROR : 
[INFO] -------------------------------------------------------------
[ERROR] Source option 5 is no longer supported. Use 6 or later.
[ERROR] Target option 1.5 is no longer supported. Use 1.6 or later.
[INFO] 2 errors 

**c)**
INFO] ------------------------------------------------------------------------
[INFO] Building jFastCGI Client: CORE 2.4-SNAPSHOT
[INFO] ------------------------------------------------------------------------
[INFO] 
[INFO] --- maven-enforcer-plugin:1.0:enforce (enforce-maven) @ client-core ---
[INFO] 
[INFO] --- maven-resources-plugin:2.6:resources (default-resources) @ client-core ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] skip non existing resourceDirectory /home/xxx/dev/git/jfastcgi/client/core/src/main/resources
[INFO] 
[INFO] --- jrebel-maven-plugin:1.1.3:generate (generate-rebel-xml) @ client-core ---
[INFO] 
[INFO] --- maven-compiler-plugin:3.1:compile (default-compile) @ client-core ---
[INFO] Changes detected - recompiling the module!
[INFO] Compiling 17 source files to /home/xxx/dev/git/jfastcgi/client/core/target/classes
[WARNING] /home/xxx/dev/git/jfastcgi/client/core/src/main/java/org/jfastcgi/client/FastCGIHandlerFactory.java: Some input files use or override a deprecated API.
[WARNING] /home/xxx/dev/git/jfastcgi/client/core/src/main/java/org/jfastcgi/client/FastCGIHandlerFactory.java: Recompile with -Xlint:deprecation for details.
[INFO] 
[INFO] --- maven-checkstyle-plugin:2.10:check (verify-style) @ client-core ---
[INFO] Downloading: http://repository.apache.org/snapshots/org/jfastcgi/parent/build-tools/2.4-SNAPSHOT/maven-metadata.xml
[INFO] Downloading: http://repository.apache.org/snapshots/org/jfastcgi/parent/build-tools/2.4-SNAPSHOT/build-tools-2.4-SNAPSHOT.pom
[WARNING] The POM for org.jfastcgi.parent:build-tools:jar:2.4-SNAPSHOT is missing, no dependency information available
[INFO] Downloading: http://repository.apache.org/snapshots/org/jfastcgi/parent/build-tools/2.4-SNAPSHOT/build-tools-2.4-SNAPSHOT.jar
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO] 
[INFO] jFastCGI Client: CORE .............................. FAILURE [  3.995 s]
[INFO] jFastCGI Client: Servlet ........................... SKIPPED
[INFO] jFastCGI Client: Portlet ........................... SKIPPED
[INFO] jFastCGI Client: Spring-Integration ................ SKIPPED
[INFO] jFastCGI Client: bundled ........................... SKIPPED
[INFO] jFastCGI Client: Play!Framework 1.x ................ SKIPPED
[INFO] jFastCGI Client: Parent ............................ SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 4.721 s
[INFO] Finished at: 2018-05-24T15:05:17+02:00
[INFO] Final Memory: 18M/67M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-checkstyle-plugin:2.10:check (verify-style) on project client-core: Execution verify-style of goal org.apache.maven.plugins:maven-checkstyle-plugin:2.10:check failed: Plugin org.apache.maven.plugins:maven-checkstyle-plugin:2.10 or one of its dependencies could not be resolved: Could not find artifact org.jfastcgi.parent:build-tools:jar:2.4-SNAPSHOT in apache.snapshots (http://repository.apache.org/snapshots) -> [Help 1]

In fact parent/build-tools is not used any more, just the checkstyle-default.xml from this directory is referenced.
maven-checkstyle-plugin is configured following this instructions:
http://maven.apache.org/plugins/maven-checkstyle-plugin/usage.html#Checking_for_Violations_as_Part_of_the_Build

**2) CONTENT_TYPE**
The request header `Content-Type` is now forwarded.

**3) More allowed headers**
Nextcloud also needs DESTINATION, OVERWRITE and X-REQUESTED-WITH request headers.